### PR TITLE
`npm audit` fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -664,13 +664,13 @@
       }
     },
     "node_modules/@jimp/jpeg": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.1.tgz",
-      "integrity": "sha512-8352zrdlCCLFdZ/J+JjBslDvml+fS3Z8gttdml0We759PnnZGqrnPRhkOEOJbNUlE+dD4ckLeIe6NPxlS/7U+w==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.2.tgz",
+      "integrity": "sha512-BW5gZydgq6wdIwHd+3iUNgrTklvoQc/FUKSj9meM6A0FU21lUaansRX5BDdJqHkyXJLnnlDGwDt27J+hQuBAVw==",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1",
-        "jpeg-js": "0.4.2"
+        "@jimp/utils": "^0.16.2",
+        "jpeg-js": "^0.4.2"
       },
       "peerDependencies": {
         "@jimp/custom": ">=0.3.5"
@@ -1022,9 +1022,9 @@
       }
     },
     "node_modules/@jimp/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-8fULQjB0x4LzUSiSYG6ZtQl355sZjxbv8r9PPAuYHzS9sGiSHJQavNqK/nKnpDsVkU88/vRGcE7t3nMU0dEnVw==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.2.tgz",
+      "integrity": "sha512-XENrPvmigiXZQ8E2nxJqO6UVvWBLzbNwyYi3Y8Q1IECoYhYI3kgOQ0fmy4G269Vz1V0omh1bNmC42r4OfXg1Jg==",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "regenerator-runtime": "^0.13.3"
@@ -9049,9 +9049,9 @@
       }
     },
     "node_modules/jpeg-js": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
-      "integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw=="
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -15592,13 +15592,13 @@
       }
     },
     "@jimp/jpeg": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.1.tgz",
-      "integrity": "sha512-8352zrdlCCLFdZ/J+JjBslDvml+fS3Z8gttdml0We759PnnZGqrnPRhkOEOJbNUlE+dD4ckLeIe6NPxlS/7U+w==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.2.tgz",
+      "integrity": "sha512-BW5gZydgq6wdIwHd+3iUNgrTklvoQc/FUKSj9meM6A0FU21lUaansRX5BDdJqHkyXJLnnlDGwDt27J+hQuBAVw==",
       "requires": {
         "@babel/runtime": "^7.7.2",
-        "@jimp/utils": "^0.16.1",
-        "jpeg-js": "0.4.2"
+        "@jimp/utils": "^0.16.2",
+        "jpeg-js": "^0.4.2"
       }
     },
     "@jimp/plugin-blit": {
@@ -15856,9 +15856,9 @@
       }
     },
     "@jimp/utils": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.1.tgz",
-      "integrity": "sha512-8fULQjB0x4LzUSiSYG6ZtQl355sZjxbv8r9PPAuYHzS9sGiSHJQavNqK/nKnpDsVkU88/vRGcE7t3nMU0dEnVw==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.2.tgz",
+      "integrity": "sha512-XENrPvmigiXZQ8E2nxJqO6UVvWBLzbNwyYi3Y8Q1IECoYhYI3kgOQ0fmy4G269Vz1V0omh1bNmC42r4OfXg1Jg==",
       "requires": {
         "@babel/runtime": "^7.7.2",
         "regenerator-runtime": "^0.13.3"
@@ -21634,9 +21634,9 @@
       }
     },
     "jpeg-js": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
-      "integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw=="
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="
     },
     "js-tokens": {
       "version": "4.0.0",


### PR DESCRIPTION
Issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/1496.

Updates `package-lock.json` with newer `jpeg-js` node module to fix high severity vulnerability.