### PR TITLE
Fixes application number error on success page

### DIFF
--- a/src/controllers/confirm.js
+++ b/src/controllers/confirm.js
@@ -37,7 +37,7 @@ const confirmController = async (request) => {
       const appNo = newAppResponse.headers.location.slice(newAppResponse.headers.location.lastIndexOf('/') + 1);
 
       // Pad with leading zeroes as required.
-      const appId = appNo.padStart(5, appNo);
+      const appId = appNo.padStart(5, 0);
 
       // Get the application ID from the location in the response.
       request.session.licenceNo = `NS-SFO-${appId}`;


### PR DESCRIPTION
The confirm page will now display correctly with a 5 digit application number with zeros if application number is less than 5 digits long.

This was a frontend issue and was to do with padStart having the wrong argument. 

Resolves: #1808

Issue: Scottish-Natural-Heritage/Licensing#1808