### PR TITLE
Fix/1670 prevent duplicate sett

### DIFF
--- a/cypress/integration/008-site-location-and-sett-details.js
+++ b/cypress/integration/008-site-location-and-sett-details.js
@@ -35,16 +35,9 @@ describe('Site Location page ', function () {
     cy.get('#main-content form button.naturescot-forward-button').click();
     // ~GET `/choose-address`~
     // FILL the form
-    // Cy.get('select[name=address]').select('10092032547');
+    cy.get('select[name=address]').select('10092032547');
     // POST `/choose-address`
-    // Cy.get('button.govuk-button[name=addressFound][value=yes]').click();
-    // Address not found
-    cy.get('#main-content form button.govuk-button--secondary').click();
-    // /manual-address
-    cy.get('input[type=text]#addressLine1').type('Nature Scot');
-    cy.get('input[type=text]#addressTown').type('Nature Scot');
-    cy.get('input[type=text]#addressCounty').type('Nature Scot');
-    cy.get('#main-content form button.naturescot-forward-button').click();
+    cy.get('button.govuk-button[name=addressFound][value=yes]').click();
   });
 
   it('should allow access if the user visits all the pages in order', function () {

--- a/cypress/integration/008-site-location-and-sett-details.js
+++ b/cypress/integration/008-site-location-and-sett-details.js
@@ -35,9 +35,16 @@ describe('Site Location page ', function () {
     cy.get('#main-content form button.naturescot-forward-button').click();
     // ~GET `/choose-address`~
     // FILL the form
-    cy.get('select[name=address]').select('10092032547');
+    // Cy.get('select[name=address]').select('10092032547');
     // POST `/choose-address`
-    cy.get('button.govuk-button[name=addressFound][value=yes]').click();
+    // Cy.get('button.govuk-button[name=addressFound][value=yes]').click();
+    // Address not found
+    cy.get('#main-content form button.govuk-button--secondary').click();
+    // /manual-address
+    cy.get('input[type=text]#addressLine1').type('Nature Scot');
+    cy.get('input[type=text]#addressTown').type('Nature Scot');
+    cy.get('input[type=text]#addressCounty').type('Nature Scot');
+    cy.get('#main-content form button.naturescot-forward-button').click();
   });
 
   it('should allow access if the user visits all the pages in order', function () {

--- a/cypress/integration/008-site-location-and-sett-details.js
+++ b/cypress/integration/008-site-location-and-sett-details.js
@@ -110,4 +110,30 @@ describe('Site Location page ', function () {
     cy.get('#main-content form button.naturescot-forward-button').click();
     cy.url().should('include', '/confirm');
   });
+
+  it('add a second sett with the same name as the first should give an error', function () {
+    cy.visit('/site-location');
+    cy.get('#main-content form button.naturescot-button--add').click();
+    cy.url().should('include', '/sett-details');
+
+    // Enter a first sett.
+    cy.get('input[type="text"]#current-sett-id').type('ABC123');
+    cy.get('input[type="text"]#current-grid-reference').type('NH60004000');
+    cy.get('input[type="text"]#current-entrances').type('3');
+
+    cy.get('#main-content form button.naturescot-forward-button').click();
+    cy.url().should('include', '/site-location');
+
+    cy.get('#main-content form button.naturescot-button--add').click();
+    cy.url().should('include', '/sett-details');
+
+    // Enter a second sett with the same details.
+    cy.get('input[type="text"]#current-sett-id').type('ABC123');
+    cy.get('input[type="text"]#current-grid-reference').type('NH60004000');
+    cy.get('input[type="text"]#current-entrances').type('3');
+
+    cy.get('#main-content form button.naturescot-forward-button').click();
+    cy.url().should('include', '/sett-details');
+    cy.get('.govuk-error-summary ul li a').should('contain', 'Enter a different Sett name');
+  });
 });

--- a/cypress/integration/008-site-location-and-sett-details.js
+++ b/cypress/integration/008-site-location-and-sett-details.js
@@ -134,6 +134,6 @@ describe('Site Location page ', function () {
 
     cy.get('#main-content form button.naturescot-forward-button').click();
     cy.url().should('include', '/sett-details');
-    cy.get('.govuk-error-summary ul li a').should('contain', 'Enter a different Sett name');
+    cy.get('.govuk-error-summary ul li a').should('contain', 'Enter a different Sett ID');
   });
 });

--- a/cypress/integration/008-site-location-and-sett-details.js
+++ b/cypress/integration/008-site-location-and-sett-details.js
@@ -136,4 +136,29 @@ describe('Site Location page ', function () {
     cy.url().should('include', '/sett-details');
     cy.get('.govuk-error-summary ul li a').should('contain', 'Enter a different Sett ID');
   });
+
+  it('add a second sett with a different name to the first then should navigate back to site location page', function () {
+    cy.visit('/site-location');
+    cy.get('#main-content form button.naturescot-button--add').click();
+    cy.url().should('include', '/sett-details');
+
+    // Enter a first sett.
+    cy.get('input[type="text"]#current-sett-id').type('ABC123');
+    cy.get('input[type="text"]#current-grid-reference').type('NH60004000');
+    cy.get('input[type="text"]#current-entrances').type('3');
+
+    cy.get('#main-content form button.naturescot-forward-button').click();
+    cy.url().should('include', '/site-location');
+
+    cy.get('#main-content form button.naturescot-button--add').click();
+    cy.url().should('include', '/sett-details');
+
+    // Enter a second sett with different ID but same grid reference.
+    cy.get('input[type="text"]#current-sett-id').type('XYZ456');
+    cy.get('input[type="text"]#current-grid-reference').type('NH60004000');
+    cy.get('input[type="text"]#current-entrances').type('1');
+
+    cy.get('#main-content form button.naturescot-forward-button').click();
+    cy.url().should('include', '/site-location');
+  });
 });

--- a/src/controllers/sett-details.js
+++ b/src/controllers/sett-details.js
@@ -17,15 +17,15 @@ const validSettId = (settId) => {
  *
  * @param {string} currentSettId A user supplied sett Id.
  * @param {Array.<object>} previousSettArray An array of sett information already entered during this session.
- * @returns {boolean} True is the sett Id is unique.
+ * @returns {boolean} True if the sett Id is unique.
  */
 const uniqueSettId = (currentSettId, previousSettArray) => {
-  // If sett list's length is 0, return true, ie it is unique.
+  // If sett array is undefined, return true, ie it is unique as no setts have been entered yet.
   if (previousSettArray === undefined) {
     return true;
   }
 
-  // If sett list's length is > 0, loop through the list of sett objects.
+  // If sett array's length is > 0, loop through the sett objects.
   if (previousSettArray.length > 0) {
     for (const sett of previousSettArray) {
       if (sett.id === currentSettId) {

--- a/src/controllers/sett-details.js
+++ b/src/controllers/sett-details.js
@@ -14,21 +14,21 @@ const validSettId = (settId) => {
 
 const uniqueSettId = (currentSettId, previousSettList) => {
   // If sett list's length is 0, return true, ie it is unique.
-  if (previousSettList.length === 0) {
+  if (previousSettList === undefined) {
     return true;
   }
 
-  // If sett list's length is >= 1, loop through the list of sett objects.
+  // If sett list's length is > 0, loop through the list of sett objects.
   if (previousSettList.length > 0) {
-    previousSettList.forEach((sett) => {
+    for (const sett of previousSettList) {
       if (sett.id === currentSettId) {
         // Return false if current sett id matches one already entered.
         return false;
       }
+    }
 
-      // Return true if it does not match another sett id.
-      return true;
-    });
+    // Return true if it does not match another sett id.
+    return true;
   }
 };
 

--- a/src/controllers/sett-details.js
+++ b/src/controllers/sett-details.js
@@ -13,7 +13,7 @@ const validSettId = (settId) => {
 };
 
 /**
- * Check a sett ID against any previously entered during the session for duplicates.
+ * Check a sett ID for duplicates against any previously entered during the session.
  *
  * @param {string} currentSettId A user supplied sett Id.
  * @param {Array.<object>} previousSettArray An array of sett information already entered during this session.

--- a/src/controllers/sett-details.js
+++ b/src/controllers/sett-details.js
@@ -152,7 +152,6 @@ const settDetailsController = (request) => {
     }
 
     request.session.setts.push(newSett);
-    console.log(request.session);
   } else {
     request.session.setts[request.session.currentSettIndex].id = formatId(request.body.currentSettId.trim());
     request.session.setts[request.session.currentSettIndex].gridReference = formatGridReference(

--- a/src/controllers/sett-details.js
+++ b/src/controllers/sett-details.js
@@ -12,15 +12,22 @@ const validSettId = (settId) => {
   return true;
 };
 
-const uniqueSettId = (currentSettId, previousSettList) => {
+/**
+ * Check a sett ID against any previously entered during the session for duplicates.
+ *
+ * @param {string} currentSettId A user supplied sett Id.
+ * @param {Array.<object>} previousSettArray An array of sett information already entered during this session.
+ * @returns {boolean} True is the sett Id is unique.
+ */
+const uniqueSettId = (currentSettId, previousSettArray) => {
   // If sett list's length is 0, return true, ie it is unique.
-  if (previousSettList === undefined) {
+  if (previousSettArray === undefined) {
     return true;
   }
 
   // If sett list's length is > 0, loop through the list of sett objects.
-  if (previousSettList.length > 0) {
-    for (const sett of previousSettList) {
+  if (previousSettArray.length > 0) {
+    for (const sett of previousSettArray) {
       if (sett.id === currentSettId) {
         // Return false if current sett id matches one already entered.
         return false;

--- a/src/controllers/sett-details.js
+++ b/src/controllers/sett-details.js
@@ -12,6 +12,25 @@ const validSettId = (settId) => {
   return true;
 };
 
+const uniqueSettId = (currentSettId, previousSettList) => {
+  // If sett list's length is 0, return true, ie it is unique.
+  if (previousSettList.length === 0) {
+    return true;
+  }
+
+  // If sett list's length is >= 1, loop through the list of sett objects.
+  if (previousSettList.length >= 1) {
+    previousSettList.forEach((sett) => {
+      if (sett.id === currentSettId) {
+        // Return false if current sett id matches one already entered.
+        return false;
+      }
+      // Return true if it does not match another sett id.
+      return true;
+    })
+  }
+};
+
 /**
  * Clean a string to remove any non-grid-ref characters.
  *
@@ -123,6 +142,7 @@ const settDetailsController = (request) => {
     }
 
     request.session.setts.push(newSett);
+    console.log(request.session);
   } else {
     request.session.setts[request.session.currentSettIndex].id = formatId(request.body.currentSettId.trim());
     request.session.setts[request.session.currentSettIndex].gridReference = formatGridReference(

--- a/src/controllers/sett-details.js
+++ b/src/controllers/sett-details.js
@@ -19,15 +19,16 @@ const uniqueSettId = (currentSettId, previousSettList) => {
   }
 
   // If sett list's length is >= 1, loop through the list of sett objects.
-  if (previousSettList.length >= 1) {
+  if (previousSettList.length > 0) {
     previousSettList.forEach((sett) => {
       if (sett.id === currentSettId) {
         // Return false if current sett id matches one already entered.
         return false;
       }
+
       // Return true if it does not match another sett id.
       return true;
-    })
+    });
   }
 };
 
@@ -113,11 +114,13 @@ const validEntrances = (entrances) => {
 
 const settDetailsController = (request) => {
   request.session.currentSettIdError = !validSettId(request.body.currentSettId);
+  request.session.uniqueSettIdError = !uniqueSettId(request.body.currentSettId, request.session.setts);
   request.session.currentGridReferenceError = !validGridReference(request.body.currentGridReference);
   request.session.currentEntrancesError = !validEntrances(request.body.currentEntrances);
 
   request.session.settDetailsError =
     request.session.currentSettIdError ||
+    request.session.uniqueSettIdError ||
     request.session.currentGridReferenceError ||
     request.session.currentEntrancesError;
 

--- a/src/views/sett-details.njk
+++ b/src/views/sett-details.njk
@@ -25,7 +25,7 @@
         } if model.currentEntrancesError,
         {
           text: "Enter a different Sett ID",
-          href: "#unique-set-id-error"
+          href: "#unique-sett-id-error"
         } if model.uniqueSettIdError
       ]
     }) }}

--- a/src/views/sett-details.njk
+++ b/src/views/sett-details.njk
@@ -22,7 +22,11 @@
         {
           text: "Enter the number of Entrances",
           href: "#current-entrances-error"
-        } if model.currentEntrancesError
+        } if model.currentEntrancesError,
+        {
+          text: "Enter a different Sett name",
+          href: "#unique-set-id-error"
+        } if model.uniqueSettIdError
       ]
     }) }}
   {% endif %}

--- a/src/views/sett-details.njk
+++ b/src/views/sett-details.njk
@@ -24,7 +24,7 @@
           href: "#current-entrances-error"
         } if model.currentEntrancesError,
         {
-          text: "Enter a different Sett name",
+          text: "Enter a different Sett ID",
           href: "#unique-set-id-error"
         } if model.uniqueSettIdError
       ]


### PR DESCRIPTION
This fix has touched:

- **src/controllers/sett-details.js:** I've created a new function in the sett-details controller to check for uniqueness of the sett Id and not added to the validSettId function that already existed because a specific error message needed to be shown on the front end to the user. I've also added JSDoc for this new function. This function is then checked for truthiness in the settDetailsController function
- **src/views/sett-details.njk:** I've added the new error message
- **cypress/integrations/008-site-details-sett-details.js:** Added two tests for (1) an error occurs when the same sett Id is entered; and (2) no error is shown when a different sett Id is added. To check these passed locally I had to change the beforeEach() so enter a manual address as my postcode lookup isn't working due to npm run start:mock not allowing page progression because of a cookies issue. I've reverted beforeEach() back to it's original state so it should run for everyone else.

Issue: Scottish-Natural-Heritage/Licensing#1670

