### PR TITLE
feature/switch-postcode-lookup-api

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -8,8 +8,7 @@ const config = Object.freeze({
   hostPrefix: process.env.SFO_HOST_PREFIX || `http://localhost:${process.env.SFO_PORT}`,
   pathPrefix: process.env.SFO_PATH_PREFIX ? `/${process.env.SFO_PATH_PREFIX}` : '/standard-forestry-operations',
   cookiePrefix: process.env.COOKIE_PREFIX || '__Secure',
-  gazetteerApiEndpoint: process.env.PC_LOOKUP_API_URL || 'https://cagmap.snh.gov.uk/gazetteer',
-  gazetteerApiKey: process.env.PC_LOOKUP_API_KEY ?? '',
+  gazetteerApiEndpoint: process.env.PC_LOOKUP_API_URL || '',
 });
 
 export {config as default};

--- a/src/utils/gazetteer.js
+++ b/src/utils/gazetteer.js
@@ -15,9 +15,6 @@ const findAddressesByPostcode = async (postcode) => {
       params: {
         postcode,
       },
-      headers: {
-        Authorization: `Bearer ${config.gazetteerApiKey}`,
-      },
       timeout: 10_000,
     });
   } catch (error) {
@@ -54,9 +51,6 @@ const findFullAddressesByUprn = async (uprn) => {
       params: {
         uprn,
         fieldset: 'all',
-      },
-      headers: {
-        Authorization: `Bearer ${config.gazetteerApiKey}`,
       },
       timeout: 10_000,
     });


### PR DESCRIPTION
Issue https://github.com/Scottish-Natural-Heritage/Licensing/issues/1888.

GIG are switching off their postcode lookup service in the next couple of weeks, this PR bypasses their proxy and connects directly to the lookup service.

The `POSTCODE_LOOKUP_API_URL` is passed in as an environment variable by Terraform, from the Licensing IaC repo, when it starts up the Docker container.