### PR TITLE
Deploy new Gazetteer API into production

### DIFF
--- a/src/controllers/confirm.js
+++ b/src/controllers/confirm.js
@@ -37,7 +37,7 @@ const confirmController = async (request) => {
       const appNo = newAppResponse.headers.location.slice(newAppResponse.headers.location.lastIndexOf('/') + 1);
 
       // Pad with leading zeroes as required.
-      const appId = appNo.padStart(5, appNo);
+      const appId = appNo.padStart(5, 0);
 
       // Get the application ID from the location in the response.
       request.session.licenceNo = `NS-SFO-${appId}`;


### PR DESCRIPTION
Using `api.publicsectormapping.gov.scot` instead of `cagmap` proxy.