### PR TITLE
feature/set-secure-cookie-attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start": "node --experimental-modules src/server.js",
     "dev": "SFO_PORT=3999 COOKIE_PREFIX=_ nodemon --exec \"npm run lint && npm run start\" -e js,njk,scss --ignore build/ --ignore dist/ --ignore cypress/",
     "cy:run": "cypress run",
-    "test": "SFO_PORT=3002 SFO_PATH_PREFIX=standard-forestry-operations COOKIE_PREFIX=_ PC_LOOKUP_API_URL=http://mock-gazetteer-api/endpoint start-server-and-test start:mock http://localhost:3002/standard-forestry-operations/health cy:run",
+    "test": "UNDER_TEST=true SFO_PORT=3002 SFO_PATH_PREFIX=standard-forestry-operations COOKIE_PREFIX=_ PC_LOOKUP_API_URL=http://mock-gazetteer-api/endpoint start-server-and-test start:mock http://localhost:3002/standard-forestry-operations/health cy:run",
     "cy:open": "cypress open"
   },
   "engines": {

--- a/src/app.js
+++ b/src/app.js
@@ -70,21 +70,21 @@ app.use(
     secret: config.sessionSecret,
     resave: true,
     saveUninitialized: false,
-  })
+  }),
 );
 
 /* eslint-enable no-unneeded-ternary */
 
 app.use(
   `${config.pathPrefix}/dist`,
-  express.static(path.join(__dirname, '..', '/dist'), {immutable: true, maxAge: '30 minutes'})
+  express.static(path.join(__dirname, '..', '/dist'), {immutable: true, maxAge: '30 minutes'}),
 );
 app.use(
   `${config.pathPrefix}/govuk-frontend`,
   express.static(path.join(__dirname, '..', '/node_modules/govuk-frontend/govuk'), {
     immutable: true,
     maxAge: '3 hours',
-  })
+  }),
 );
 
 // `health` is a simple health-check end-point to test whether the service is


### PR DESCRIPTION
Sets the secure attribute on a cookie. Needed as part of the work to replace Nginx with Caddy, issue https://github.com/Scottish-Natural-Heritage/Deer-Online-Services/issues/976.