### PR TITLE
feature/update-application-use-node-24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 # Builder Stage
 ################################################################################
 
-# we're deploying to the node:20-alpine image, so do our building on it too
-FROM node:20-alpine as builder
+# we're deploying to the node:24-alpine image, so do our building on it too
+FROM node:24-alpine AS builder
 
 # node-gyp runs as part of the npm install, so we need to install dependencies
 # we need git for cypress as it's using a custom version of requests that
@@ -31,8 +31,8 @@ RUN npm ci && npm prune --production
 # Deployable Image
 ################################################################################
 
-# we built on the node:20-alpine image, so we need to deploy on it too
-FROM node:20-alpine
+# we built on the node:24-alpine image, so we need to deploy on it too
+FROM node:24-alpine
 
 # drop back to the non-privileged user for run-time
 WORKDIR /home/node
@@ -48,13 +48,13 @@ RUN mkdir -p ./dist
 
 # these variables are for overriding but keep them consistent between image and
 # run
-ENV SFO_PORT 3002
-ENV SFO_PATH_PREFIX standard-forestry-operations
+ENV SFO_PORT=3002
+ENV SFO_PATH_PREFIX=standard-forestry-operations
 
 # these variables are for overriding and they only matter during run
-ENV PC_LOOKUP_API_KEY override_this_value
-ENV SFO_SESSION_SECRET override_this_value
-ENV SFO_API_URL override_this_value
+ENV PC_LOOKUP_API_KEY=override_this_value
+ENV SFO_SESSION_SECRET=override_this_value
+ENV SFO_API_URL=override_this_value
 
 # let docker know about our listening port
 EXPOSE $SFO_PORT

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cy:open": "cypress open"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=24.0.0"
   },
   "browserslist": "> 0.5%, last 2 versions, not dead",
   "dependencies": {


### PR DESCRIPTION
Node.js 20 reached end-of-life at the end of April.

Updates the Dockerfile to use the `node:24-alpine` image for building and deploying, and updates the `engine` field in package.json to `24`.

Fixes the `LegacyKeyValueFormat` warning in the logs.
Fixes the `FromAsCasing` warning in the logs.